### PR TITLE
Tags being cut off in a short description

### DIFF
--- a/js/FeedEk.js
+++ b/js/FeedEk.js
@@ -31,6 +31,7 @@
                         s += '<div class="itemDate">' + i.toLocaleDateString() + "</div>";
                     }
                     if (def.ShowDesc) {
+                        item.content = item.content.replace(/<(script|img|embed|object|applet|iframe)[^>]*>/gi, '');
                         if (def.DescCharacterLimit > 0 && item.content.length > def.DescCharacterLimit) {
                             s += '<div class="itemContent">' + item.content.substr(0, def.DescCharacterLimit) + "...</div>";
                         }


### PR DESCRIPTION
Remove self-contained tags from the post description that can break down when the plugin cuts off the long description to a certain length.
Prevent a situation like this: "Long description with an image <img sr.." - string length limit (100char)
