### PR TITLE
Added custom success, fail, progress event handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,31 @@ Please visit [format examples](http://momentjs.com/docs/#/displaying/format/) an
 
 Check out [FeedEk examples](http://jquery-plugins.net/FeedEk/FeedEk-examples.html) page for date format usage.
 
+**- With your own Success/Fail/Progress event handlers**
+
+```
+$('#divRss').FeedEk({
+    FeedUrl : 'http://rss.cnn.com/rss/edition.rss',
+  }).then(function(){ /*success*/ }, function(){ /*fail*/ }, function(){ /*progress*/ });
+```
+
+```
+var feed1 = $('#divRss').FeedEk({
+    FeedUrl : 'http://rss.cnn.com/rss/edition.rss',
+  });
+
+feed1.done(function(){ /*success*/ });
+```
+
+```
+var feed1 = $('#divRss').FeedEk({
+    FeedUrl : 'http://rss.cnn.com/rss/edition.rss',
+  });
+
+feed1.always(function(){ /*do this on success or fail*/ });
+```
+
+See the [jQuery Promise](http://api.jquery.com/deferred.promise/) documentation for more options
 
 ## Options
 

--- a/js/FeedEk.js
+++ b/js/FeedEk.js
@@ -6,6 +6,9 @@
 
 (function ($) {
     $.fn.FeedEk = function (opt) {
+        var timestamp = new Date();
+        timestamp = timestamp.getSeconds() + "." + timestamp.getMilliseconds();
+
         var def = $.extend({
             FeedUrl: "http://rss.cnn.com/rss/edition.rss",
             MaxCount: 5,
@@ -14,11 +17,14 @@
             CharacterLimit: 0,
             TitleLinkTarget: "_blank",
             DateFormat: "",
-            DateFormatLang:"en"
+            DateFormatLang: "en",
+            ImageRoot: ""
         }, opt);
 
-        var id = $(this).attr("id"), i, s = "",dt;
-        $("#" + id).empty().append('<img src="loader.gif" />');
+        console.log(timestamp + " " + def.FeedUrl);
+
+        var id = $(this).attr("id"), i, s = "", dt;
+        $("#" + id).empty().append('<img src="' + def.ImageRoot + 'loader.gif" />');
 
         return $.ajax({
             url: "http://ajax.googleapis.com/ajax/services/feed/load?v=1.0&num=" + def.MaxCount + "&output=json&q=" + encodeURIComponent(def.FeedUrl) + "&hl=en&callback=?",
@@ -26,21 +32,7 @@
             success: function (data) {
                 var timestamp = new Date();
                 timestamp = timestamp.getSeconds() + "." + timestamp.getMilliseconds();
-                console.log(timestamp + " " + def.FeedUrl + " .success()");
-
-                timestamp = new Date();
-                timestamp = timestamp.getSeconds() + "." + timestamp.getMilliseconds();
-                var sleepingInfo = timestamp + " " + def.FeedUrl + " sleeping";
-
-                for (var i = 0; i < 10000000;) {
-                    sleepingInfo += ".";
-                    i++;
-                }
-                console.log(sleepingInfo);
-
-                timestamp = new Date();
-                timestamp = timestamp.getSeconds() + "." + timestamp.getMilliseconds();
-                console.log(timestamp + " " + def.FeedUrl + " awake");
+                console.log(timestamp + " " + def.FeedUrl + " FeedEk.success()");
 
                 $("#" + id).empty();
                 $.each(data.responseData.feed.entries, function (e, item) {
@@ -72,7 +64,7 @@
 
                 timestamp = new Date();
                 timestamp = timestamp.getSeconds() + "." + timestamp.getMilliseconds();
-                console.log(timestamp + " " + def.FeedUrl + " .success() complete");
+                console.log(timestamp + " " + def.FeedUrl + " FeedEk.success() complete");
             }
         }).promise();
     };

--- a/js/FeedEk.js
+++ b/js/FeedEk.js
@@ -17,14 +17,13 @@
             CharacterLimit: 0,
             TitleLinkTarget: "_blank",
             DateFormat: "",
-            DateFormatLang: "en",
-            ImageRoot: ""
+            DateFormatLang: "en"
         }, opt);
 
         console.log(timestamp + " " + def.FeedUrl);
 
         var id = $(this).attr("id"), i, s = "", dt;
-        $("#" + id).empty().append('<img src="' + def.ImageRoot + 'loader.gif" />');
+        $("#" + id).empty().append('<img src="loader.gif" />');
 
         return $.ajax({
             url: "http://ajax.googleapis.com/ajax/services/feed/load?v=1.0&num=" + def.MaxCount + "&output=json&q=" + encodeURIComponent(def.FeedUrl) + "&hl=en&callback=?",

--- a/js/FeedEk.js
+++ b/js/FeedEk.js
@@ -20,10 +20,28 @@
         var id = $(this).attr("id"), i, s = "",dt;
         $("#" + id).empty().append('<img src="loader.gif" />');
 
-        $.ajax({
+        return $.ajax({
             url: "http://ajax.googleapis.com/ajax/services/feed/load?v=1.0&num=" + def.MaxCount + "&output=json&q=" + encodeURIComponent(def.FeedUrl) + "&hl=en&callback=?",
             dataType: "json",
             success: function (data) {
+                var timestamp = new Date();
+                timestamp = timestamp.getSeconds() + "." + timestamp.getMilliseconds();
+                console.log(timestamp + " " + def.FeedUrl + " .success()");
+
+                timestamp = new Date();
+                timestamp = timestamp.getSeconds() + "." + timestamp.getMilliseconds();
+                var sleepingInfo = timestamp + " " + def.FeedUrl + " sleeping";
+
+                for (var i = 0; i < 10000000;) {
+                    sleepingInfo += ".";
+                    i++;
+                }
+                console.log(sleepingInfo);
+
+                timestamp = new Date();
+                timestamp = timestamp.getSeconds() + "." + timestamp.getMilliseconds();
+                console.log(timestamp + " " + def.FeedUrl + " awake");
+
                 $("#" + id).empty();
                 $.each(data.responseData.feed.entries, function (e, item) {
                     s += '<li><div class="itemTitle"><a href="' + item.link + '" target="' + def.TitleLinkTarget + '" >' + item.title + "</a></div>";
@@ -51,7 +69,11 @@
                     }
                 });
                 $("#" + id).append('<ul class="feedEkList">' + s + "</ul>");
+
+                timestamp = new Date();
+                timestamp = timestamp.getSeconds() + "." + timestamp.getMilliseconds();
+                console.log(timestamp + " " + def.FeedUrl + " .success() complete");
             }
-        });
+        }).promise();
     };
 })(jQuery);


### PR DESCRIPTION
Modified FeedEk to return the promise object so that success/fail/progress events can be chained on. An example calling the basic FeedEk functionality, with success, fail, and progress event functions chained on.

```
$('#divRss').FeedEk({
    FeedUrl : 'http://rss.cnn.com/rss/edition.rss',
  }).then(function(){ /*success*/ }, function(){ /*fail*/ }, function(){ /*progress*/ });
```

See the [jQuery Promise](http://api.jquery.com/deferred.promise/) documentation for more options
