### PR TITLE
Sort feed items, moment.locale() instead of moment.lang()

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ You can obtain feeds easily from any domain. No need for server-side scripts.
         ShowDesc : true,
         ShowPubDate:true,
         DescCharacterLimit:100,
-        TitleLinkTarget:'_blank'
+        TitleLinkTarget:'_blank',
+        ResultSortBy:'title',
+        ResultDescend:true,
       });
 
 **- With Date Format Options**
@@ -79,6 +81,10 @@ Check out [FeedEk examples](http://jquery-plugins.net/FeedEk/FeedEk-examples.htm
   Option for Feed Publish Date Format. Default is none
 - **DateFormatLang**
   Option for Feed Publish Date Format Language for localization. Default is `en`
+- **ResultSortBy**
+  Sort results by title (`ResultSortBy:"title"`) or publish date (`ResultSortBy:"pubdate"`). Defaults to `""` (no sort).
+- **ResultDescend**
+  Sort results with descending order (`ResultDescend:true`) or ascending order (`ResultDescend:false`). Defaults to `false`. This option has effect only if `ResultSortBy` is set.
 
 ## Demo
 

--- a/js/FeedEk.js
+++ b/js/FeedEk.js
@@ -13,7 +13,9 @@
             DescCharacterLimit: 0,
             TitleLinkTarget: "_blank",
             DateFormat: "",
-            DateFormatLang:"en"
+            DateFormatLang:"en",
+            ResultSortBy: "",
+            ResultDescend: false
         }, opt);
         
         var id = $(this).attr("id"), i, s = "", dt;
@@ -21,7 +23,18 @@
         if (def.FeedUrl == undefined) return;       
         $("#" + id).append('<img src="loader.gif" />');
 
-        var YQLstr = 'SELECT channel.item FROM feednormalizer WHERE output="rss_2.0" AND url ="' + def.FeedUrl + '" LIMIT ' + def.MaxCount;
+        var YQLstr = 'SELECT channel.item FROM feednormalizer WHERE output="rss_2.0" AND url ="' + def.FeedUrl + '"';
+        
+        if (def.ResultSortBy == "title") {
+			YQLstr = YQLstr + ' | sort(field="channel.item.title", descending="'+def.ResultDescend.toString()+'")';
+		}
+		else if (def.ResultSortBy == "pubdate") {
+			YQLstr = YQLstr + ' | sort(field="channel.item.pubDate", descending="'+def.ResultDescend.toString()+'")';
+		}
+		
+		YQLstr = YQLstr + ' | truncate(count=' + def.MaxCount + ')';
+		
+		console.log(YQLstr);
 
         $.ajax({
             url: "https://query.yahooapis.com/v1/public/yql?q=" + encodeURIComponent(YQLstr) + "&format=json&diagnostics=false&callback=?",

--- a/js/FeedEk.js
+++ b/js/FeedEk.js
@@ -52,7 +52,7 @@
                         s += '<div class="itemDate">';
                         if ($.trim(def.DateFormat).length > 0) {
                             try {
-                                moment.lang(def.DateFormatLang);
+                                moment.locale(def.DateFormatLang);
                                 s += moment(dt).format(def.DateFormat);
                             }
                             catch (e){s += dt.toLocaleDateString();}                            


### PR DESCRIPTION
# Sort items by publish date or title in ascending/descending order

- Needed the sort feature in my own project
- Noticed that YQL supports sorting (https://developer.yahoo.com/yql/guide/select.html, see functions)

# Use moment.locale() instead of moment.lang(), which is deprecate

- moment complains to the browser log that moment.lang() is deprecated and should be replaced by moment.locale()
