### PR TITLE
Re-enable Atom feed parsing since move to YQL

### DIFF
--- a/FeedEk_demo.html
+++ b/FeedEk_demo.html
@@ -10,12 +10,12 @@
     <script type="text/javascript" src="js/FeedEk.js"></script>
     <script type="text/javascript">
         $(document).ready(function () {
-            $('#divRss').FeedEk({
+            $('#divRss').FeedEkRss({
                 FeedUrl: 'http://jquery-plugins.net/rss',
                 MaxCount: 3
             });
 
-            $('#divRss2').FeedEk({
+            $('#divRss2').FeedEkRss({
                 FeedUrl: 'http://jquery-plugins.net/rss',
                 MaxCount: 4,
                 ShowDesc: true,
@@ -23,85 +23,85 @@
                 DescCharacterLimit: 100
             });
 
-            $('#divRss3').FeedEk({
+            $('#divRss3').FeedEkRss({
                 FeedUrl: 'http://jquery-plugins.net/rss',
                 MaxCount: 5,
                 ShowDesc: false
             });
 
-            $('#divRss4').FeedEk({
+            $('#divRss4').FeedEkRss({
                 FeedUrl: 'http://jquery-plugins.net/rss',
                 MaxCount: 2,
                 DateFormat: 'L',
                 DateFormatLang: 'en'
             });
 
-            $('#divRss5').FeedEk({
+            $('#divRss5').FeedEkRss({
                 FeedUrl: 'http://jquery-plugins.net/rss',
                 MaxCount: 2,
                 DateFormat: 'L',
                 DateFormatLang: 'tr'
             });
 
-            $('#divRss6').FeedEk({
+            $('#divRss6').FeedEkRss({
                 FeedUrl: 'http://jquery-plugins.net/rss',
                 MaxCount: 2,
                 DateFormat: 'L',
                 DateFormatLang: 'en-gb'
             });
 
-            $('#divRss7').FeedEk({
+            $('#divRss7').FeedEkRss({
                 FeedUrl: 'http://jquery-plugins.net/rss',
                 MaxCount: 2,
                 DateFormat: 'LL',
                 DateFormatLang: 'en'
             });
 
-            $('#divRss8').FeedEk({
+            $('#divRss8').FeedEkRss({
                 FeedUrl: 'http://jquery-plugins.net/rss',
                 MaxCount: 2,
                 DateFormat: 'LLL',
                 DateFormatLang: 'en'
             });
 
-            $('#divRss9').FeedEk({
+            $('#divRss9').FeedEkRss({
                 FeedUrl: 'http://jquery-plugins.net/rss',
                 MaxCount: 2,
                 DateFormat: 'll',
                 DateFormatLang: 'en'
             });
-            $('#divRss10').FeedEk({
+            $('#divRss10').FeedEkRss({
                 FeedUrl: 'http://jquery-plugins.net/rss',
                 MaxCount: 2,
                 DateFormat: 'lll',
                 DateFormatLang: 'en'
             });
 
-            $('#divRss11').FeedEk({
+            $('#divRss11').FeedEkRss({
                 FeedUrl: 'http://jquery-plugins.net/rss',
                 MaxCount: 2,
                 DateFormat: 'DD MMMM YYYY',
                 DateFormatLang: 'en'
             });
-            $('#divRss12').FeedEk({
+            $('#divRss12').FeedEkRss({
                 FeedUrl: 'http://jquery-plugins.net/rss',
                 MaxCount: 2,
                 DateFormat: 'MM/DD/YYYY'
             });
 
-            $('#divRss13').FeedEk({
+            $('#divRss13').FeedEkRss({
                 FeedUrl: 'http://jquery-plugins.net/rss',
                 MaxCount: 2,
                 DateFormat: 'MM/DD/YYYY HH:mm'
             });
 
-            $('#divRss14').FeedEk({
+            $('#divRss14').FeedEkRss({
                 FeedUrl: 'http://jquery-plugins.net/rss',
                 MaxCount: 2,
                 DateFormat: 'MM-DD-YYYY'
             });
 
-            $('#divRss15').FeedEk({
+            $('#divRss15').FeedEkRss({
                 FeedUrl: 'http://jquery-plugins.net/rss',
                 MaxCount: 2,
                 DateFormat: 'MM-DD-YYYY HH:mm'
@@ -117,7 +117,7 @@
 </head>
 <body>
   <div style="padding:10px;">
-    <h1>FeedEk Examples</h1>
+    <h1>FeedEkRss Examples</h1>
     <div>
         <div class="rssDiv">
             <p>
@@ -126,7 +126,7 @@
             <div id="divRss"></div>
             <strong>Code</strong>
             <pre class="prettyprint">
-$('#divRss').FeedEk({
+$('#divRss').({
   FeedUrl: 'http://jquery-plugins.net/rss',
   MaxCount: 2
 });
@@ -140,7 +140,7 @@ $('#divRss').FeedEk({
             <div id="divRss2"></div>
             <strong>Code</strong>
             <pre class="prettyprint">
-$('#divRss').FeedEk({
+$('#divRss').FeedEkRss({
   FeedUrl: 'http://jquery-plugins.net/rss',
   MaxCount: 3,
   ShowDesc: true,
@@ -157,7 +157,7 @@ $('#divRss').FeedEk({
             <div id="divRss3"></div>
             <strong>Code</strong>
             <pre class="prettyprint">
-$('#divRss').FeedEk({
+$('#divRss').FeedEkRss({
   FeedUrl: 'http://jquery-plugins.net/rss',
   MaxCount: 4,
   ShowDesc: false
@@ -176,7 +176,7 @@ $('#divRss').FeedEk({
             <div id="divRss4"></div>
             <strong>Code</strong>
             <pre class="prettyprint">
-$('#divRss').FeedEk({
+$('#divRss').FeedEkRss({
   FeedUrl: 'http://jquery-plugins.net/rss',
   MaxCount: 2,
   DateFormat: 'L',
@@ -189,7 +189,7 @@ $('#divRss').FeedEk({
             <div id="divRss5"></div>
             <strong>Code</strong>
             <pre class="prettyprint">
-$('#divRss').FeedEk({
+$('#divRss').FeedEkRss({
   FeedUrl: 'http://jquery-plugins.net/rss',
   MaxCount: 2,
   DateFormat: 'L',
@@ -202,7 +202,7 @@ $('#divRss').FeedEk({
             <div id="divRss6"></div>
             <strong>Code</strong>
             <pre class="prettyprint">
-$('#divRss').FeedEk({
+$('#divRss').FeedEkRss({
   FeedUrl: 'http://jquery-plugins.net/rss',
   MaxCount: 2,
   DateFormat: 'L',
@@ -219,7 +219,7 @@ $('#divRss').FeedEk({
             <div id="divRss7"></div>
             <strong>Code</strong>
             <pre class="prettyprint">
-$('#divRss').FeedEk({
+$('#divRss').FeedEkRss({
   FeedUrl: 'http://jquery-plugins.net/rss',
   MaxCount: 2,
   DateFormat: 'LL',
@@ -232,7 +232,7 @@ $('#divRss').FeedEk({
             <div id="divRss8"></div>
             <strong>Code</strong>
             <pre class="prettyprint">
-$('#divRss').FeedEk({
+$('#divRss').FeedEkRss({
   FeedUrl: 'http://jquery-plugins.net/rss',
   MaxCount: 2,
   DateFormat: 'LLL',
@@ -245,7 +245,7 @@ $('#divRss').FeedEk({
             <div id="divRss9"></div>
             <strong>Code</strong>
             <pre class="prettyprint">
-$('#divRss').FeedEk({
+$('#divRss').FeedEkRss({
   FeedUrl: 'http://jquery-plugins.net/rss',
   MaxCount: 2,
   DateFormat: 'll',
@@ -262,7 +262,7 @@ $('#divRss').FeedEk({
             <div id="divRss10"></div>
             <strong>Code</strong>
             <pre class="prettyprint">
-$('#divRss').FeedEk({
+$('#divRss').FeedEkRss({
   FeedUrl: 'http://jquery-plugins.net/rss',
   MaxCount: 2,
   DateFormat: 'lll',
@@ -275,7 +275,7 @@ $('#divRss').FeedEk({
             <div id="divRss11"></div>
             <strong>Code</strong>
             <pre class="prettyprint">
-$('#divRss').FeedEk({
+$('#divRss').FeedEkRss({
   FeedUrl: 'http://jquery-plugins.net/rss',
   MaxCount: 2,
   DateFormat: 'DD MMMM YYYY',
@@ -288,7 +288,7 @@ $('#divRss').FeedEk({
             <div id="divRss12"></div>
             <strong>Code</strong>
             <pre class="prettyprint">
-$('#divRss').FeedEk({
+$('#divRss').FeedEkRss({
   FeedUrl: 'http://jquery-plugins.net/rss',
   MaxCount: 2,
   DateFormat: 'MM/DD/YYYY'
@@ -304,7 +304,7 @@ $('#divRss').FeedEk({
             <div id="divRss13"></div>
             <strong>Code</strong>
             <pre class="prettyprint">
-$('#divRss').FeedEk({
+$('#divRss').FeedEkRss({
   FeedUrl: 'http://jquery-plugins.net/rss',
   MaxCount: 2,
   DateFormat: 'MM/DD/YYYY HH:mm'
@@ -316,7 +316,7 @@ $('#divRss').FeedEk({
             <div id="divRss14"></div>
             <strong>Code</strong>
             <pre class="prettyprint">
-$('#divRss').FeedEk({
+$('#divRss').FeedEkRss({
   FeedUrl: 'http://jquery-plugins.net/rss',
   MaxCount: 2,
   DateFormat: 'MM-DD-YYYY'
@@ -328,7 +328,7 @@ $('#divRss').FeedEk({
             <div id="divRss15"></div>
             <strong>Code</strong>
             <pre class="prettyprint">
-$('#divRss').FeedEk({
+$('#divRss').FeedEkRss({
   FeedUrl: 'http://jquery-plugins.net/rss',
   MaxCount: 2,
   DateFormat: 'MM-DD-YYYY HH:mm'

--- a/js/FeedEk.js
+++ b/js/FeedEk.js
@@ -1,11 +1,11 @@
 /*
 * FeedEk jQuery RSS/ATOM Feed Plugin v3.0 with YQL API
 * http://jquery-plugins.net/FeedEk/FeedEk.html  https://github.com/enginkizil/FeedEk
-* Author : Engin KIZIL http://www.enginkizil.com   
+* Author : Engin KIZIL http://www.enginkizil.com
 */
 
 (function ($) {
-    $.fn.FeedEk = function (opt) {
+    $.fn.FeedEkRss = function (opt) {
         var def = $.extend({
             MaxCount: 5,
             ShowDesc: true,
@@ -15,10 +15,10 @@
             DateFormat: "",
             DateFormatLang:"en"
         }, opt);
-        
+
         var id = $(this).attr("id"), i, s = "", dt;
         $("#" + id).empty();
-        if (def.FeedUrl == undefined) return;       
+        if (def.FeedUrl == undefined) return;
         $("#" + id).append('<img src="loader.gif" />');
 
         var YQLstr = 'SELECT channel.item FROM feednormalizer WHERE output="rss_2.0" AND url ="' + def.FeedUrl + '" LIMIT ' + def.MaxCount;
@@ -33,7 +33,7 @@
                 }
                 $.each(data.query.results.rss, function (e, itm) {
                     s += '<li><div class="itemTitle"><a href="' + itm.channel.item.link + '" target="' + def.TitleLinkTarget + '" >' + itm.channel.item.title + '</a></div>';
-                    
+
                     if (def.ShowPubDate){
                         dt = new Date(itm.channel.item.pubDate);
                         s += '<div class="itemDate">';
@@ -42,7 +42,7 @@
                                 moment.lang(def.DateFormatLang);
                                 s += moment(dt).format(def.DateFormat);
                             }
-                            catch (e){s += dt.toLocaleDateString();}                            
+                            catch (e){s += dt.toLocaleDateString();}
                         }
                         else {
                             s += dt.toLocaleDateString();
@@ -64,4 +64,62 @@
             }
         });
     };
+
+    $.fn.FeedEkAtom = function (opt) {
+    var def = $.extend({
+        MaxCount: 5,
+        ShowDesc: true,
+        ShowPubDate: true,
+        DescCharacterLimit: 0,
+        TitleLinkTarget: "_blank",
+        DateFormat: "",
+        DateFormatLang:"en"
+    }, opt);
+
+    var id = $(this).attr("id"), i, s = "", dt;
+    $("#" + id).empty();
+    if (def.FeedUrl == undefined) return;
+    $("#" + id).append('<img src="loader.gif" />');
+
+    var YQLstr = 'SELECT entry FROM feednormalizer WHERE output="atom_1.0" AND url ="' + def.FeedUrl + '" LIMIT ' + def.MaxCount;
+
+    $.ajax({
+        url: "https://query.yahooapis.com/v1/public/yql?q=" + encodeURIComponent(YQLstr) + "&format=json&diagnostics=false&callback=?",
+        dataType: "json",
+        success: function (data) {
+            $("#" + id).empty();
+            console.log(data.query.results.feed);
+            if (!(data.query.results.feed instanceof Array)) {
+                data.query.results.feed = [data.query.results.feed];
+            }
+            $.each(data.query.results.feed, function (e, itm) {
+                s += '<li><div class="itemTitle"><a href="' + itm.entry.link.href + '" target="' + def.TitleLinkTarget + '" >' + itm.entry.title + '</a></div>';
+                if (def.ShowPubDate){
+                    dt = new Date(itm.entry.pubDate);
+                    s += '<div class="itemDate">';
+                    if ($.trim(def.DateFormat).length > 0) {
+                        try {
+                            moment.lang(def.DateFormatLang);
+                            s += moment(dt).format(def.DateFormat);
+                        }
+                        catch (e){s += dt.toLocaleDateString();}
+                    }
+                    else {
+                        s += dt.toLocaleDateString();
+                    }
+                    s += '</div>';
+                }
+                if (def.ShowDesc) {
+                    //console.log(itm.entry.summary.div.blockquote.p);
+                    s += '<div class="itemContent">';
+                    var summary = itm.entry.summary;
+                    s += JSON.stringify(summary);
+                    s += '</div>';
+                }
+            });
+            $("#" + id).append('<ul class="feedEkList">' + s + '</ul>');
+        }
+    });
+};
+
 })(jQuery);

--- a/js/FeedEk.js
+++ b/js/FeedEk.js
@@ -93,7 +93,13 @@
                 data.query.results.feed = [data.query.results.feed];
             }
             $.each(data.query.results.feed, function (e, itm) {
-                s += '<li><div class="itemTitle"><a href="' + itm.entry.link.href + '" target="' + def.TitleLinkTarget + '" >' + itm.entry.title + '</a></div>';
+                if (itm.entry.title.hasOwnProperty('type') ){
+                  var title = itm.entry.title.content;
+                }
+                else{
+                  var title = itm.entry.title;
+                }
+                s += '<li><div class="itemTitle"><a href="' + itm.entry.link.href + '" target="' + def.TitleLinkTarget + '" >' + title + '</a></div>';
                 if (def.ShowPubDate){
                     dt = new Date(itm.entry.pubDate);
                     s += '<div class="itemDate">';


### PR DESCRIPTION
I believe the move to YQL with [FeedEk 3.0](cfc40b5aae6f013b6edaf20963b03942e7d2e4f2) had Atom feeds working, but somewhere, something (probably in YQL) has changed, and the query format is different now.

Multiple issues ( #52, #53, #55, #35) point to the error created by the unassigned values on https://github.com/enginkizil/FeedEk/blob/master/js/FeedEk.js#L31

I renamed and duplicated the FeedEd function located in `js/FeedEk.js` to be able to parse ATOM feeds, by adjusting the YQL to parse xml. Ather assignations of the results needed to be changed throughout the variable, but I'm not certain all of them are working properly.

The chart at https://en.wikipedia.org/wiki/RSS#RSS_compared_with_Atom was used to make the assignation adjustments, but I'm having trouble conforming to keys, because in the two Atom feeds I have tested, keys are not used in similar ways. For example: http://gitlab.com/colmoneill.atom and http://github.com/colmoneill.atom bot use the `title` key but **gitlab** uses title as a string, **github** used title as a dict with a `type` object. This is examplified by f583f646043dbbb7a752da624f40239e323a6f36.

I'm looking for ways and help to deal with these different renderings, but maybe there are enough people here already to work on this.

Thanks for any help,
all the best, 